### PR TITLE
Fix an error where the logfile isn't created yet, then can't be found and opened by the logger

### DIFF
--- a/dll/src/lib.rs
+++ b/dll/src/lib.rs
@@ -45,6 +45,7 @@ pub unsafe extern "system" fn DllMain(
                 simplelog::LevelFilter::Trace,
                 simplelog::Config::default(),
                 File::options()
+                    .create(true)
                     .write(true)
                     .truncate(true)
                     .open("arxan-disabler-dll.log")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/69dc1e45-f0e6-4925-85b1-ccdd66147d36)
